### PR TITLE
Portal; Publish TS src

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -11,5 +11,8 @@ jest.setup.ts
 .gitignore
 # --
 docs
-src
 tsconfig.tsbuildinfo
+tsconfig.json
+tsconfig.build.json
+declaration.d.ts
+package-lock.json

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc58",
+  "version": "0.1.0-rc59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-components",
-      "version": "0.1.0-rc58",
+      "version": "0.1.0-rc59",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "^2.11.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc59",
+  "version": "0.1.0-rc64",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-components",
-      "version": "0.1.0-rc59",
+      "version": "0.1.0-rc64",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "^2.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc59",
+  "version": "0.1.0-rc61",
   "author": {
     "name": "Kevin Wang",
     "url": "https://thekevinwang.com"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc58",
+  "version": "0.1.0-rc59",
   "author": {
     "name": "Kevin Wang",
     "url": "https://thekevinwang.com"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc61",
+  "version": "0.1.0-rc65",
   "author": {
     "name": "Kevin Wang",
     "url": "https://thekevinwang.com"

--- a/packages/core/src/components/Drawer/Drawer.tsx
+++ b/packages/core/src/components/Drawer/Drawer.tsx
@@ -1,13 +1,8 @@
 import React from "react";
 import clsx from "clsx";
-import { useRef } from "react";
 import useMeasure from "react-use-measure";
-import {
-  useOverlay,
-  usePreventScroll,
-  OverlayContainer,
-  OverlayProvider,
-} from "@react-aria/overlays";
+import { usePreventScroll } from "@react-aria/overlays";
+import Portal from "@reach/portal";
 // import { FocusScope } from "@react-aria/focus";
 
 interface Props {
@@ -15,41 +10,35 @@ interface Props {
   onDismiss?: () => void;
 }
 
-const isBrowser = typeof window !== "undefined";
-
 const Drawer: React.ComponentType<Props> = ({ children, show, onDismiss }) => {
   usePreventScroll({ isDisabled: !show });
-
-  // This ref needs to be attached to the modal
-  let ref = useRef();
-  let { overlayProps } = useOverlay(
-    { isDismissable: true, isOpen: show, onClose: onDismiss },
-    ref
-  );
 
   // useMeasure will update through window resize
   const [ref2, bounds] = useMeasure();
 
-  return isBrowser ? (
-    <OverlayProvider>
-      <OverlayContainer>
-        <div className={clsx("geist-drawer", { show: show })}>
-          <div className={clsx("geist-drawer-overlay")} {...overlayProps} />
-          <div
-            className={clsx("geist-drawer-container")}
-            style={{
-              height: bounds.height + 20,
-              transform: `translate3d(0px, ${show ? "0px" : "100%"}, 102px)`,
-            }}
-          >
-            <div ref={ref}>
-              <div ref={ref2}>{children}</div>
-            </div>
+  return (
+    <Portal>
+      <div className={clsx("geist-drawer", { show: show })}>
+        <div
+          className={clsx("geist-drawer-overlay")}
+          onClick={() => {
+            onDismiss?.();
+          }}
+        />
+        <div
+          className={clsx("geist-drawer-container")}
+          style={{
+            height: bounds.height + 20,
+            transform: `translate3d(0px, ${show ? "0px" : "100%"}, 102px)`,
+          }}
+        >
+          <div>
+            <div ref={ref2}>{children}</div>
           </div>
         </div>
-      </OverlayContainer>
-    </OverlayProvider>
-  ) : null;
+      </div>
+    </Portal>
+  );
 };
 
 export default Drawer;

--- a/packages/core/src/components/Toast/ToastArea.test.tsx
+++ b/packages/core/src/components/Toast/ToastArea.test.tsx
@@ -1,4 +1,4 @@
-import { render, RenderResult, screen, act } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ToastArea from "./ToastArea";
@@ -18,11 +18,6 @@ jest.mock("@react-aria/interactions");
 const useHoverMock = mocked(useHover);
 
 jest.useFakeTimers();
-jest.mock("@react-aria/overlays", () => ({
-  __esModule: true,
-  OverlayContainer: ({ children }) => <>{children}</>,
-  OverlayProvider: ({ children }) => <>{children}</>,
-}));
 jest.mock("components/Button", () => ({
   __esModule: true,
   Button: (props) => <button {...props} />,
@@ -53,9 +48,9 @@ describe("ToastArea", () => {
   // GIVEN
   it("should render without any errors", () => {
     // WHEN
-    const { container } = render(<ToastArea />);
+    const { baseElement } = render(<ToastArea />);
     // THEN
-    expect(container).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
   });
 
   // GIVEN
@@ -67,8 +62,8 @@ describe("ToastArea", () => {
       } as unknown as IToastsContext;
     });
 
-    const { container } = render(<ToastArea />);
-    const toastArea = container.firstChild;
+    const { baseElement } = render(<ToastArea />);
+    const toastArea = baseElement.getElementsByClassName("toast-area")[0];
 
     // THEN
     expect(toastArea).toHaveClass("multiple");

--- a/packages/core/src/components/Toast/ToastArea.tsx
+++ b/packages/core/src/components/Toast/ToastArea.tsx
@@ -2,13 +2,11 @@ import React from "react";
 import { useRef, useReducer } from "react";
 import clsx from "clsx";
 import { useHover } from "@react-aria/interactions";
-import { OverlayProvider, OverlayContainer } from "@react-aria/overlays";
+import Portal from "@reach/portal";
 
 import useToasts from "./useToasts";
 import styles from "./toasts.module.css";
 import ToastContainer from "./ToastContainer";
-
-const isBrowser = typeof window !== `undefined`;
 
 function useForceUpdate(): () => void {
   return useReducer(() => ({}), {})[1];
@@ -24,40 +22,37 @@ const ToastArea = () => {
 
   const forceUpdate = useForceUpdate();
 
-  if (!isBrowser) return null;
   return (
-    <OverlayProvider>
-      <OverlayContainer>
-        <div
-          {...hoverProps}
-          className={clsx("toast-area", styles.toastArea, {
-            [styles.multiple]: messages.length > 1,
-          })}
-        >
-          {messages.map((e, i) => {
-            return (
-              <ToastContainer
-                key={e.key}
-                hovering={isHovered}
-                position={messages.length - 1 - i}
-                text={e.text}
-                height={e.height}
-                heights={heights.current}
-                remove={() => {
-                  current?.removeToastByKey(e.key);
-                }}
-                type={e.type}
-                preserve={e.preserve}
-                action={e.action}
-                cancelAction={e.cancelAction}
-                id={e.key}
-                onMount={forceUpdate}
-              />
-            );
-          })}
-        </div>
-      </OverlayContainer>
-    </OverlayProvider>
+    <Portal>
+      <div
+        {...hoverProps}
+        className={clsx("toast-area", styles.toastArea, {
+          [styles.multiple]: messages.length > 1,
+        })}
+      >
+        {messages.map((e, i) => {
+          return (
+            <ToastContainer
+              key={e.key}
+              hovering={isHovered}
+              position={messages.length - 1 - i}
+              text={e.text}
+              height={e.height}
+              heights={heights.current}
+              remove={() => {
+                current?.removeToastByKey(e.key);
+              }}
+              type={e.type}
+              preserve={e.preserve}
+              action={e.action}
+              cancelAction={e.cancelAction}
+              id={e.key}
+              onMount={forceUpdate}
+            />
+          );
+        })}
+      </div>
+    </Portal>
   );
 };
 

--- a/packages/core/src/components/Toast/ToastsProvider.test.tsx
+++ b/packages/core/src/components/Toast/ToastsProvider.test.tsx
@@ -7,11 +7,7 @@ import useToasts from "./useToasts";
 import ToastArea from "./ToastArea";
 
 jest.useFakeTimers();
-jest.mock("@react-aria/overlays", () => ({
-  __esModule: true,
-  OverlayContainer: ({ children }) => <>{children}</>,
-  OverlayProvider: ({ children }) => <>{children}</>,
-}));
+
 jest.mock("components/Button", () => ({
   __esModule: true,
   Button: (props) => <button {...props} />,
@@ -49,9 +45,9 @@ describe("ToastConsumer", () => {
   // GIVEN
   it("should open a toast", () => {
     // WHEN
-    const { container } = render(<ToastConsumer />, { wrapper });
+    const { baseElement } = render(<ToastConsumer />, { wrapper });
     const button = screen.getByRole("button");
-    const toastArea = container.children[1];
+    const toastArea = baseElement.getElementsByClassName("toast-area")[0];
 
     // THEN
     expect(toastArea.children).toHaveLength(0);
@@ -71,9 +67,9 @@ describe("ToastConsumer", () => {
   // GIVEN
   it("should auto clear toasts", () => {
     // WHEN
-    const { container } = render(<ToastConsumer />, { wrapper });
+    const { baseElement } = render(<ToastConsumer />, { wrapper });
     const button = screen.getByRole("button");
-    const toastArea = container.children[1];
+    const toastArea = baseElement.getElementsByClassName("toast-area")[0];
 
     act(() => {
       userEvent.click(button);
@@ -104,9 +100,9 @@ describe("ToastConsumer", () => {
         </button>
       );
     };
-    const { container } = render(<ToastConsumer />, { wrapper });
+    const { baseElement } = render(<ToastConsumer />, { wrapper });
     const button = screen.getByRole("button");
-    const toastArea = container.children[1];
+    const toastArea = baseElement.getElementsByClassName("toast-area")[0];
 
     // WHEN
     act(() => {

--- a/packages/core/src/components/Toast/__snapshots__/ToastArea.test.tsx.snap
+++ b/packages/core/src/components/Toast/__snapshots__/ToastArea.test.tsx.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ToastArea should render without any errors 1`] = `
-<div>
-  <div
-    class="toast-area toastArea"
-  />
-</div>
+<body>
+  <div />
+  <reach-portal>
+    <div
+      class="toast-area toastArea"
+    />
+  </reach-portal>
+</body>
 `;

--- a/packages/core/src/components/Toast/__snapshots__/ToastsProvider.test.tsx.snap
+++ b/packages/core/src/components/Toast/__snapshots__/ToastsProvider.test.tsx.snap
@@ -5,8 +5,5 @@ exports[`ToastConsumer should render without any errors 1`] = `
   <button>
     Show toast
   </button>
-  <div
-    class="toast-area toastArea"
-  />
 </DocumentFragment>
 `;

--- a/packages/core/src/contexts/ThemeContext/ThemeContext.ts
+++ b/packages/core/src/contexts/ThemeContext/ThemeContext.ts
@@ -1,14 +1,9 @@
 import { createContext } from "react";
 
-export enum Modes {
-  LIGHT = "light",
-  DARK = "dark",
-  SYSTEM = "system",
-}
 export interface IThemeContext {
-  selectTheme: (val: Modes | "light" | "dark" | "system" | string) => void;
+  selectTheme: (val: "light" | "dark" | "system" | string) => void;
   isDarkMode: null | boolean;
-  mode: Modes | "light" | "dark" | "system";
+  mode: "light" | "dark" | "system";
 }
 
 export const ThemeContext = createContext<IThemeContext>({

--- a/packages/core/src/contexts/ThemeContext/ThemeContextProvider.tsx
+++ b/packages/core/src/contexts/ThemeContext/ThemeContextProvider.tsx
@@ -1,24 +1,21 @@
 import { isBrowser } from "../../utils/isBrowser";
 import { useMediaQuery } from "../../hooks";
-import { Modes, ThemeContext } from "./ThemeContext";
+import { ThemeContext } from "./ThemeContext";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 
 const STORAGE_KEY = "mode";
 
 const ThemeContextProvider = ({ children }) => {
   const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
 
-  const [mode, setMode] = useState<Modes>(() => {
+  const [mode, setMode] = useState<"light" | "dark" | "system">(() => {
     if (isBrowser()) {
       return (window as any).__mode;
     }
   });
 
-  const isDarkMode = useMemo(
-    () => (mode === Modes.SYSTEM ? prefersDark : mode === Modes.DARK),
-    [mode, prefersDark]
-  );
+  const isDarkMode = mode === "system" ? prefersDark : mode === "dark";
 
   useEffect(() => {
     if (isDarkMode) {
@@ -28,30 +25,13 @@ const ThemeContextProvider = ({ children }) => {
     }
   }, [isDarkMode]);
 
-  const selectTheme = async (val: Modes | "light" | "dark" | "system") => {
-    switch (val) {
-      case Modes.LIGHT:
-        setMode(Modes.LIGHT);
-        localStorage.setItem(STORAGE_KEY, Modes.LIGHT);
-        break;
-      case Modes.DARK:
-        setMode(Modes.DARK);
-        localStorage.setItem(STORAGE_KEY, Modes.DARK);
-        break;
-      case Modes.SYSTEM:
-        setMode(Modes.SYSTEM);
-        localStorage.setItem(STORAGE_KEY, Modes.SYSTEM);
-        break;
-    }
+  const selectTheme = (val: "light" | "dark" | "system") => {
+    setMode(val);
+    localStorage.setItem(STORAGE_KEY, val);
   };
 
-  const contextValue = useMemo(
-    () => ({ isDarkMode, mode, selectTheme }),
-    [isDarkMode, selectTheme]
-  );
-
   return (
-    <ThemeContext.Provider value={contextValue}>
+    <ThemeContext.Provider value={{ isDarkMode, mode, selectTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/packages/docs/components/DesignLayout/DesignLayoutInner.tsx
+++ b/packages/docs/components/DesignLayout/DesignLayoutInner.tsx
@@ -19,6 +19,7 @@ import { Text } from "nextjs-components/src/components/Text";
 import { useToasts } from "nextjs-components/src/components/Toast";
 import { KBD } from "nextjs-components/src/components/KeyboardInput";
 import { Capacity } from "nextjs-components/src/components/Capacity";
+import Modal from "nextjs-components/src/components/Modal";
 import {
   Entity,
   EntityField,
@@ -125,6 +126,7 @@ const editorScope = {
   MenuItem,
   MenuWrapper,
   MenuLink,
+  Modal,
   MoreHorizontal,
   Spacer,
   Spinner,

--- a/packages/docs/package-lock.json
+++ b/packages/docs/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../core": {
       "name": "nextjs-components",
-      "version": "0.1.0-rc56",
+      "version": "0.1.0-rc58",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "^2.11.2",

--- a/packages/docs/pages/design/entity.mdx
+++ b/packages/docs/pages/design/entity.mdx
@@ -37,7 +37,7 @@ export const getStaticProps = async () => {
   <EntityField active={false} title="Inactive" description="This field is inactive" />
   <EntityField width="20%" title="Fixed Width" description={<Link color tab href="/docs">Open docs</Link>} />
   <EntityField label width={100} title="Label" description={<i>Encrypted</i>} />
-  <EntityField right description="Right Aligned" avatar={<Avatar size={24} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />} />
+  <EntityField right description="Right Aligned" avatar={<Avatar size={24} src="https://thekevinwang.com/image/kevin.webp" />} />
 </Entity>
 ```
 
@@ -65,7 +65,7 @@ export const getStaticProps = async () => {
     placeholder={!isMounted}
     thumbnail={
       <EntityThumbnail wrap size={36}>
-        <Avatar size={36} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />
+        <Avatar size={36} src="https://thekevinwang.com/image/kevin.webp" />
       </EntityThumbnail>
     }
   >
@@ -98,7 +98,7 @@ export const getStaticProps = async () => {
 >
   <EntityField title="PUBLIC_KEY" description="Production"/>
   <EntityField label title="VALUE" description="6863EFA205B4680BE7928E"/>
-  <EntityField right width={200} description="Added 1h ago" avatar={<Avatar size={24} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />}/>
+  <EntityField right width={200} description="Added 1h ago" avatar={<Avatar size={24} src="https://thekevinwang.com/image/kevin.webp" />}/>
 </Entity>
 ```
 
@@ -123,7 +123,7 @@ export const getStaticProps = async () => {
   placeholder={!isMounted}
   thumbnail={
     <EntityThumbnail wrap size={32}>
-      <Avatar size={32} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />
+      <Avatar size={32} src="https://thekevinwang.com/image/kevin.webp" />
     </EntityThumbnail>
   }
   menuItems={<>
@@ -190,7 +190,7 @@ export const getStaticProps = async () => {
     placeholder
     thumbnail={
       <EntityThumbnail wrap size={32}>
-        <Avatar size={32} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />
+        <Avatar size={32} src="https://thekevinwang.com/image/kevin.webp" />
       </EntityThumbnail>
     }
     checkbox={
@@ -217,7 +217,7 @@ export const getStaticProps = async () => {
     placeholder
     thumbnail={
       <EntityThumbnail wrap size={32}>
-        <Avatar size={32} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />
+        <Avatar size={32} src="https://thekevinwang.com/image/kevin.webp" />
       </EntityThumbnail>
     }
     menuItems={<>

--- a/packages/docs/pages/design/menu.mdx
+++ b/packages/docs/pages/design/menu.mdx
@@ -94,7 +94,7 @@ export const getStaticProps = async () => {
 ```
 <MenuWrapper>
   <MenuButton variant="unstyled">
-    <Avatar size={30} src="https://vercel.com/api/www/avatar/?u=thekevinwang&s=72" />
+    <Avatar size={30} src="https://thekevinwang.com/image/kevin.webp" />
   </MenuButton>
   <Menu width={200}>
     <MenuItem>One</MenuItem>

--- a/packages/docs/pages/design/modal.mdx
+++ b/packages/docs/pages/design/modal.mdx
@@ -1,0 +1,68 @@
+import { DesignLayout, DesignLayoutInner } from "../../components/DesignLayout";
+
+export default function Wrapper({ children, paths }) {
+  return (
+    <DesignLayout paths={paths}>
+      <DesignLayoutInner>{children}</DesignLayoutInner>
+    </DesignLayout>
+  );
+}
+export const getStaticProps = async () => {
+  const fs = await import("fs");
+  const path = await import("path");
+  const dir = path.join(process.cwd(), "pages/design");
+  const paths = fs
+    .readdirSync(dir)
+    .map((e) => path.join("/design", e.replace(".mdx", "")));
+  return {
+    props: {
+      paths,
+    },
+  };
+};
+
+# Modal
+
+<Text h4 Component="h2" type="secondary" style={{ fontWeight: 400 }}>
+  Display popup content that requires attention or provides additional
+  information.
+</Text>
+
+<Spacer y={2} />
+
+### Default
+
+```
+() => {
+  const [active, setActive] = useState(false)
+
+  return (
+    <>
+      <Button  onClick={() => setActive(true)}>Open Modal</Button>
+
+      <Modal.Modal active={active} onClickOutside={() => setActive(false)}>
+        <Modal.Body>
+          <Modal.Header>
+            <Modal.Title>Modal</Modal.Title>
+            <Modal.Subtitle>
+              This is a modal.
+            </Modal.Subtitle>
+          </Modal.Header>
+
+          <Text noMargin>Some content contained within the modal.</Text>
+        </Modal.Body>
+
+        <Modal.Actions>
+          <Modal.Action onClick={() => setActive(false)}>
+            Cancel
+          </Modal.Action>
+
+          <Modal.Action onClick={() => setActive(false)}>
+            Submit
+          </Modal.Action>
+        </Modal.Actions>
+      </Modal.Modal>
+    </>
+  )
+}
+```


### PR DESCRIPTION
# Description

This replaces some `@react-aria/overlays` usage with `@reach/portal` (closer parity with Vercel)

This adds `/design/modal` to the docs project

This simplifies ThemeContext by removing an extraneous enum,

This updates the `.npmignore` file to now publish untranspiled TS source code. This enables a consumer to import from `nextjs-components/src/...`
- Anecdotal improvement here is that this avoids the extra imports that `babel` adds to the top transpiled files.
  - <details open>
      <summary>example</summary>

      ```js

      var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");

      Object.defineProperty(exports, "__esModule", {
        value: true
      });
      exports["default"] = void 0;

      var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));

      var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));

      var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));

      ```
    </details>