### PR TITLE
fix(`LI`) ensure id (and other props are passed along (`v0.1.0-rc66`)

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc64",
+  "version": "0.1.0-rc66",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-components",
-      "version": "0.1.0-rc64",
+      "version": "0.1.0-rc66",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "^2.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-components",
-  "version": "0.1.0-rc65",
+  "version": "0.1.0-rc66",
   "author": {
     "name": "Kevin Wang",
     "url": "https://thekevinwang.com"

--- a/packages/core/src/components/List/LI.tsx
+++ b/packages/core/src/components/List/LI.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-const LI: React.ComponentType = ({ children }) => {
+const LI: React.ComponentType = ({ children, ...props }) => {
   return (
-    <li>
+    <li {...props}>
       {children}
       <style jsx>{`
         li {

--- a/packages/core/src/components/List/OL.tsx
+++ b/packages/core/src/components/List/OL.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-const OL: React.ComponentType = ({ children }) => {
+const OL: React.ComponentType = ({ children, ...props }) => {
   return (
-    <ol>
+    <ol {...props}>
       {children}
       <style jsx>{`
         ol {

--- a/packages/core/src/components/List/UL.tsx
+++ b/packages/core/src/components/List/UL.tsx
@@ -3,9 +3,9 @@ import React from "react";
  * Notes
  * https://github.com/vercel/styled-jsx/issues/121#issuecomment-280332737
  */
-const UL: React.ComponentType = ({ children }) => {
+const UL: React.ComponentType = ({ children, ...props }) => {
   return (
-    <ul>
+    <ul {...props}>
       {children}
       <style jsx>{`
         ul {


### PR DESCRIPTION
# Description

This popped up as an issue when I was attempting to use `remark-gfm`'s Footnotes feature. Prior to this change, the `id` would not be passed to the `<LI>` component

`id` attributes are added 2 places:
1. to the "ref" (`data-footnote-ref`) links
  ![image](https://user-images.githubusercontent.com/26389321/152702825-c6baa2dc-8409-43b9-bd66-308a05ac8d07.png)

2. To the `li` parent element of "backref" (`data-footnote-backref`) links
  ![image](https://user-images.githubusercontent.com/26389321/152702792-a44418c1-db93-4a9e-878a-8118e71efdcc.png)


- fix: ensure`id` is passed to LI
- chore: `v0.1.0-rc66`
