### PR TITLE
🤖 2.12.1

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-components",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-components",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "2.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-components",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "author": {
     "name": "Kevin Wang",
     "url": "https://thekevinwang.com"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed

* fix(breadcrumbs): don't require `type` prop by @thiskevinwang in https://github.com/nextjs-components/nextjs-components/pull/180


**Full Changelog**: https://github.com/nextjs-components/nextjs-components/compare/v2.12.0...v2.12.1